### PR TITLE
Fixes cloning from the main repository URL

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -105,8 +105,7 @@ if [ -d ~/Downloads/arch-hyprland ] ;then
 fi
 
 # Clone the packages
-# git clone --depth 1 https://github.com/McZlik/arch-hyprland.git
-git clone --depth 1 --branch feature/first-setup https://github.com/McZlik/arch-hyprland.git
+ git clone --depth 1 https://github.com/McZlik/arch-hyprland.git
 
 echo ":: Installation files cloned into Downloads folder"
 


### PR DESCRIPTION
Updates the setup script to clone directly from the main repository URL instead of a specific branch.
This ensures users get the latest version of the project.